### PR TITLE
Commenting out gatsby's config and going with html.js

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -45,6 +45,7 @@ export const onInitialClientRender = () => {
   }
 
   if (ga && ga.ua) {
+    console.log("here man")
     const src = `https://www.googletagmanager.com/gtag/js?id=${ga.ua}`;
     const onLoad = () => googleAnalytics(pathname);
     scripts.push(loadScript(src, onLoad));

--- a/src/html.js
+++ b/src/html.js
@@ -1,0 +1,40 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+export default function HTML(props) {
+  return (
+    <html {...props.htmlAttributes}>
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="x-ua-compatible" content="ie=edge" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, shrink-to-fit=no"
+        />
+        {/* We participate in the US government's analytics program. See the data at analytics.usa.gov. */}
+        {/* Using this instead of the gatsby config because the gatsby config sends out 2 calls to google tag manager instead of one at the moment (8.10.21) */}
+        <script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=FEHRM" id="_fed_an_ua_tag"></script>
+
+        {props.headComponents}
+      </head>
+      <body {...props.bodyAttributes}>
+        {props.preBodyComponents}
+        <div
+          key={`body`}
+          id="___gatsby"
+          dangerouslySetInnerHTML={{ __html: props.body }}
+        />
+        {props.postBodyComponents}
+      </body>
+    </html>
+  )
+}
+
+HTML.propTypes = {
+  htmlAttributes: PropTypes.object,
+  headComponents: PropTypes.array,
+  bodyAttributes: PropTypes.object,
+  preBodyComponents: PropTypes.array,
+  body: PropTypes.string,
+  postBodyComponents: PropTypes.array,
+}


### PR DESCRIPTION
Going with the snippet in the html.js file over the gatsby config because the gatsby config makes 2 calls at a time to Google for some reason. this could be a bug in the starter project.